### PR TITLE
Make `check_names()` use `.result` and `.solution` by default

### DIFF
--- a/R/check_names.R
+++ b/R/check_names.R
@@ -17,14 +17,21 @@
 #' @inherit check_table return
 #' @export
 
-check_names <- function(object, expected, max_diffs = 3) {
-  unit <- if (inherits(object, "data.frame")) "a column {named}" else "the name"
+check_names <- function(object = .result, expected = .solution, max_diffs = 3) {
+  if (inherits(object, ".result")) {
+    object <- get(".result", parent.frame())
+  }
+  if (inherits(expected, ".solution")) {
+    expected <- get(".solution", parent.frame())
+  }
   
   assert_internally({
     checkmate::assert_number(max_diffs, lower = 1)
     checkmate::assert_data_frame(object)
     checkmate::assert_data_frame(expected)
   })
+  
+  unit <- if (inherits(object, "data.frame")) "a column {named}" else "the name"
   
   names_exp <- names(expected)
   names_obj <- names(object)

--- a/man/check_names.Rd
+++ b/man/check_names.Rd
@@ -4,7 +4,7 @@
 \alias{check_names}
 \title{Check that the names of two object are the same}
 \usage{
-check_names(object, expected, max_diffs = 3)
+check_names(object = .result, expected = .solution, max_diffs = 3)
 }
 \arguments{
 \item{object}{A data frame to be compared to \code{expected}.}


### PR DESCRIPTION
Unlike other `check_` functions, `check_names()` does not currently have default arguments for `object` and `expected`. This sets  `.result` and `.solution` as defaults so `check_names()` works the same as the other functions.