### PR TITLE
Remove concept of "inconsequential" class differences

### DIFF
--- a/R/check_class.R
+++ b/R/check_class.R
@@ -13,20 +13,8 @@
 #'
 #' @param object An object to be compared to `expected`.
 #' @param expected An object containing the expected result.
-#' @param all_differences `[logical(1)]`\cr If `FALSE`, the default,
-#'   inconsequential class differences will be skipped.
-#'   If `TRUE`, all class differences will be reported.
-#'   See section "Inconsequential differences" for more information.
 #' @inheritParams tbl_check
 #' @inheritDotParams gradethis::fail -message
-#' 
-#' @section Inconsequential differences:
-#' Unless `all_differences` is set to `TRUE`, the following class differences
-#' will not generate a problem:
-#' 
-#' - [integer] vs. [numeric]
-#' - [POSIXct] vs. [POSIXlt]
-#' - [glue][glue::glue] vs. [character]
 #'
 #' @return If there are any issues, a [list] from `tbl_check_class()` and
 #'   `vec_check_class()` or a [gradethis::fail()] message from
@@ -51,7 +39,6 @@
 tbl_check_class <- function(
   object = .result,
   expected = .solution,
-  all_differences = FALSE,
   env = parent.frame()
 ) {
   if (inherits(object, ".result")) {
@@ -65,10 +52,6 @@ tbl_check_class <- function(
   exp_class <- class(expected)
   
   if (!identical(obj_class, exp_class)) {
-    if (!all_differences && has_inconsequential_class_diff(obj_class, exp_class)) {
-      return(invisible())
-    }
-    
     problem(
       "class",
       exp_class,
@@ -90,12 +73,11 @@ vec_check_class <- tbl_check_class
 tbl_grade_class <- function(
   object = .result,
   expected = .solution,
-  all_differences = FALSE,
   env = parent.frame(),
   ...
 ) {
   tblcheck_grade(
-    tbl_check_class(object, expected, all_differences, env),
+    tbl_check_class(object, expected, env),
     env = env,
     ...
   )
@@ -126,26 +108,6 @@ tblcheck_message.class_problem <- function(problem, ...) {
   problem$actual   <- friendly_class(problem$actual,   problem$actual_length)
   
   glue::glue_data(problem, problem$msg)
-}
-
-has_inconsequential_class_diff <- function(exp_class, obj_class) {
-  diff <- union(setdiff(exp_class, obj_class), setdiff(obj_class, exp_class))
-  
-  inconsequential_diff_list <- list(
-    c("integer", "numeric"),
-    c("glue"),
-    c("POSIXct", "POSIXlt")
-  )
-  
-  # Check if the differences between `exp_class` and `obj_class` is in the
-  # list of inconsequential class differences
-  for (inconsequential_diff in inconsequential_diff_list) {
-    if (unordered_identical(diff, inconsequential_diff)) {
-      return(TRUE)
-    }
-  }
-  
-  FALSE
 }
 
 hinted_class_message <- function(obj_class, exp_class) {

--- a/man/tbl_check_class.Rd
+++ b/man/tbl_check_class.Rd
@@ -7,24 +7,13 @@
 \alias{vec_grade_class}
 \title{Checks that two objects have the same classes}
 \usage{
-tbl_check_class(
-  object = .result,
-  expected = .solution,
-  all_differences = FALSE,
-  env = parent.frame()
-)
+tbl_check_class(object = .result, expected = .solution, env = parent.frame())
 
-vec_check_class(
-  object = .result,
-  expected = .solution,
-  all_differences = FALSE,
-  env = parent.frame()
-)
+vec_check_class(object = .result, expected = .solution, env = parent.frame())
 
 tbl_grade_class(
   object = .result,
   expected = .solution,
-  all_differences = FALSE,
   env = parent.frame(),
   ...
 )
@@ -32,7 +21,6 @@ tbl_grade_class(
 vec_grade_class(
   object = .result,
   expected = .solution,
-  all_differences = FALSE,
   env = parent.frame(),
   ...
 )
@@ -41,11 +29,6 @@ vec_grade_class(
 \item{object}{An object to be compared to \code{expected}.}
 
 \item{expected}{An object containing the expected result.}
-
-\item{all_differences}{\verb{[logical(1)]}\cr If \code{FALSE}, the default,
-inconsequential class differences will be skipped.
-If \code{TRUE}, all class differences will be reported.
-See section "Inconsequential differences" for more information.}
 
 \item{env}{The environment in which to find \code{.result} and \code{.solution}.}
 
@@ -82,17 +65,6 @@ informative message with \code{\link[gradethis:graded]{gradethis::fail()}}
 
 \enumerate{
 \item \code{class}: The object does not have the expected classes
-}
-}
-
-\section{Inconsequential differences}{
-
-Unless \code{all_differences} is set to \code{TRUE}, the following class differences
-will not generate a problem:
-\itemize{
-\item \link{integer} vs. \link{numeric}
-\item \link{POSIXct} vs. \link{POSIXlt}
-\item \link[glue:glue]{glue} vs. \link{character}
 }
 }
 

--- a/tests/testthat/_snaps/check_class.md
+++ b/tests/testthat/_snaps/check_class.md
@@ -38,10 +38,10 @@
         it is a vector of text (class `character`).
       >
 
-# tbl_grade_class() ignores inconsequential mismatches
+# tbl_grade_class() does not ignore formerly inconsequential mismatches
 
     Code
-      grade_int_dbl_all
+      grade_int_dbl
     Output
       <gradethis_graded: [Incorrect]
         Your result should be a number (class `numeric`), but it is an
@@ -51,7 +51,7 @@
 ---
 
     Code
-      grade_glue_chr_all
+      grade_glue_chr
     Output
       <gradethis_graded: [Incorrect]
         Your result should be a text string (class `character`), but it is an
@@ -61,7 +61,7 @@
 ---
 
     Code
-      grade_posix_ct_lt_all
+      grade_posix_ct_lt
     Output
       <gradethis_graded: [Incorrect]
         Your result should be a vector of date-times (class `POSIXlt`), but

--- a/tests/testthat/test-check_class.R
+++ b/tests/testthat/test-check_class.R
@@ -80,7 +80,7 @@ test_that("tbl_grade_class()", {
   )
 })
 
-test_that("tbl_grade_class() ignores inconsequential mismatches", {
+test_that("tbl_grade_class() does not ignore formerly inconsequential mismatches", {
   grade_int_dbl <-
     tblcheck_test_grade({
       .result   <- 1L
@@ -88,19 +88,10 @@ test_that("tbl_grade_class() ignores inconsequential mismatches", {
       tbl_grade_class()
     })
   
-  expect_null(grade_int_dbl)
-  
-  grade_int_dbl_all <-
-    tblcheck_test_grade({
-      .result   <- 1L
-      .solution <- 1
-      tbl_grade_class(all_differences = TRUE)
-    })
-  
-  expect_snapshot(grade_int_dbl_all)
+  expect_snapshot(grade_int_dbl)
   
   expect_equal(
-    grade_int_dbl_all$problem,
+    grade_int_dbl$problem,
     problem(
       type     = "class",
       expected = "numeric",
@@ -117,19 +108,10 @@ test_that("tbl_grade_class() ignores inconsequential mismatches", {
       tbl_grade_class()
     })
   
-  expect_null(grade_glue_chr)
-  
-  grade_glue_chr_all <-
-    tblcheck_test_grade({
-      .result   <- glue::glue("x")
-      .solution <- "x"
-      tbl_grade_class(all_differences = TRUE)
-    })
-  
-  expect_snapshot(grade_glue_chr_all)
+  expect_snapshot(grade_glue_chr)
   
   expect_equal(
-    grade_glue_chr_all$problem,
+    grade_glue_chr$problem,
     problem(
       type     = "class",
       expected = "character",
@@ -146,19 +128,10 @@ test_that("tbl_grade_class() ignores inconsequential mismatches", {
       tbl_grade_class()
     })
   
-  expect_null(grade_posix_ct_lt)
-  
-  grade_posix_ct_lt_all <-
-    tblcheck_test_grade({
-      .result   <- as.POSIXct(c("2021-07-29 15:18:00", "1996-03-05 12:00:00"))
-      .solution <- as.POSIXlt(c("2021-07-29 15:18:00", "1996-03-05 12:00:00"))
-      tbl_grade_class(all_differences = TRUE)
-    })
-  
-  expect_snapshot(grade_posix_ct_lt_all)
+  expect_snapshot(grade_posix_ct_lt)
   
   expect_equal(
-    grade_posix_ct_lt_all$problem,
+    grade_posix_ct_lt$problem,
     problem(
       type     = "class",
       expected = c("POSIXlt", "POSIXt"),


### PR DESCRIPTION
`class` checking now finds all differences in classes. This remove previous behavior that would ignore a small set of "inconsequential" differences:

- `integer` vs. `numeric`
- `character` vs. `glue`
- `POSIXct` vs. `POSIXlt`

Surfacing all class differences increases compatibility with other `tblcheck` and `gradethis` functions, like `vec_grade_values()` and `pass_if_equal()`, which may fail because of class differences that `vec_check_class()` previously deemed inconsequential.

This change will require exercise authors to take care in instances where a student may plausibly provide an answer with either of two classes. However, this tradeoff is worthwhile, because these problems were still likely to surface in less identifiable places (e.g. `vec_check_values()` or `pass_if_equal()`).

Closes #71.