### PR TITLE
Fix bug in `values` check with `NA` values

### DIFF
--- a/R/check_values.R
+++ b/R/check_values.R
@@ -70,7 +70,7 @@ vec_check_values <- function(
   return_if_problem(vec_check_dimensions(object, expected))
 
   # Check if values are the same
-  if (!all(vctrs::vec_equal(object, expected))) {
+  if (!all(vctrs::vec_equal(object, expected, na_equal = TRUE))) {
     return(problem("values", expected, object))
   }
 }
@@ -121,7 +121,8 @@ tblcheck_message.values_problem <- function(problem, max_diffs = 3, ...) {
     !all(
       vctrs::vec_equal(
         problem$expected[seq_len(problem$n_values)],
-        problem$actual[seq_len(problem$n_values)]
+        problem$actual[seq_len(problem$n_values)],
+        na_equal = TRUE
       )
     )
   ) {

--- a/tests/testthat/_snaps/check_values.md
+++ b/tests/testthat/_snaps/check_values.md
@@ -38,6 +38,16 @@
         `6`, `7`, `8`, `9`, and `10`.
       >
 
+# NA values
+
+    Code
+      grade_na
+    Output
+      <gradethis_graded: [Incorrect]
+        The first 3 values of your result should be `TRUE`, `TRUE`, and
+        `TRUE`, not `TRUE`, `TRUE`, and `NA`.
+      >
+
 # vec_grade_values() failures
 
     Code

--- a/tests/testthat/test-check_values.R
+++ b/tests/testthat/test-check_values.R
@@ -39,6 +39,30 @@ test_that("value differences", {
   expect_equal(grade_Inf$problem, grade_default$problem)
 })
 
+test_that("NA values", {
+  grade_na <- tblcheck_test_grade({
+    .result   <- c(TRUE, TRUE, NA)
+    .solution <- c(TRUE, TRUE, TRUE)
+    vec_grade_values()
+  })
+
+  expect_snapshot(grade_na)
+
+  expect_equal(
+    grade_na$problem,
+    problem("values", c(TRUE, TRUE, TRUE), c(TRUE, TRUE, NA)),
+    ignore_attr = "class"
+  )
+
+  grade_na_match <- tblcheck_test_grade({
+    .result   <- c(TRUE, TRUE, NA)
+    .solution <- c(TRUE, TRUE, NA)
+    vec_grade_values()
+  })
+
+  expect_null(grade_na_match)
+})
+
 test_that("vec_grade_values() failures", {
   grade_length <- tblcheck_test_grade({
     .result   <- 1:9


### PR DESCRIPTION
Use `vctrs::vec_equal(na_equal = TRUE)` in `values` check so `NA` values don't cause an error.

``` r
library(tblcheck)

.result   <- c(TRUE, TRUE, NA)
.solution <- c(TRUE, TRUE, TRUE)
vec_grade_values()
#> <gradethis_graded: [Incorrect]
#>   The first 3 values of your result should be `TRUE`, `TRUE`, and
#>   `TRUE`, not `TRUE`, `TRUE`, and `NA`.
#> >
```

<sup>Created on 2021-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #93.