### PR TITLE
Print maximum of 3 significant digits in messages

### DIFF
--- a/R/utils.R
+++ b/R/utils.R
@@ -14,7 +14,7 @@ NULL
 
 md_code <- function(x) {
   if (!length(x)) return(x)
-  paste0("`", x, "`")
+  paste0("`", trimws(format(x, digits = 3)), "`")
 }
 
 combine_words_with_more <- function(


### PR DESCRIPTION
``` r
library(tblcheck)

vec <- c(100, 200, 300, 400)

vec_check_values(vec * 1.23, vec / 1.23)
#> <tblcheck problem>
#> The first 3 values of your result should be `81.3`, `162.6`, and `243.9`, not `123`, `246`, and `369`.
#> $ type    : chr "values"
#> $ expected: num [1:4] 81.3 162.6 243.9 325.2
#> $ actual  : num [1:4] 123 246 369 492
```

<sup>Created on 2021-11-18 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Uses `trimws()`, which isn't available in R < 3.3. Is that a concern?

Closes #94.