### PR TITLE
Fix column values problem message

### DIFF
--- a/R/check_values.R
+++ b/R/check_values.R
@@ -133,21 +133,20 @@ tblcheck_message.values_problem <- function(problem, max_diffs = 3, ...) {
       md_code(problem$actual[seq_len(problem$n_values)])
     )
 
-    if (is_problem(problem, "column")) {
-      problem$expected_msg <- problem$expected_msg %||%
+    problem$expected_msg <- problem$expected_msg %||%
+      if (is_problem(problem, "column")) {
         ngettext(
           problem$n_values,
           "The first value of your `{column}` column should be {expected}, not {actual},",
           "The first {n_values} values of your `{column}` column should be {expected},"
         )
-    }
-
-    problem$expected_msg <- problem$expected_msg %||%
-      ngettext(
-        problem$n_values,
-        "The first value of your result should be {expected},",
-        "The first {n_values} values of your result should be {expected},"
-      )
+      } else {
+        ngettext(
+          problem$n_values,
+          "The first value of your result should be {expected},",
+          "The first {n_values} values of your result should be {expected},"
+        )
+      }
 
     problem$actual_message <- problem$actual_message %||%
       " not {actual}."
@@ -165,19 +164,20 @@ tblcheck_message.values_problem <- function(problem, max_diffs = 3, ...) {
       seq_len(min(max_diffs, length(problem$unexpected)))
     ]
 
-    if (is_problem(problem, "column")) {
-      problem$msg <- ngettext(
-        length(problem$unexpected),
-        "I didn't expect your `{column}` column to include the value {unexpected}.",
-        "I didn't expect your `{column}` column to include the values {unexpected}."
-      )
-    }
-
-    problem$msg <- ngettext(
-      length(problem$unexpected),
-      "I didn't expect your result to include the value {unexpected}.",
-      "I didn't expect your result to include the values {unexpected}."
-    )
+    problem$msg <-
+      if (is_problem(problem, "column")) {
+        ngettext(
+          length(problem$unexpected),
+          "I didn't expect your `{column}` column to include the value {unexpected}.",
+          "I didn't expect your `{column}` column to include the values {unexpected}."
+        )
+      } else {
+        ngettext(
+          length(problem$unexpected),
+          "I didn't expect your result to include the value {unexpected}.",
+          "I didn't expect your result to include the values {unexpected}."
+        )
+      }
 
     problem$unexpected <- knitr::combine_words(md_code(problem$unexpected))
 
@@ -191,20 +191,20 @@ tblcheck_message.values_problem <- function(problem, max_diffs = 3, ...) {
     problem$missing <- problem$missing[
       seq_len(min(max_diffs, length(problem$missing)))
     ]
-
-    if (is_problem(problem, "column")) {
-      problem$msg <- ngettext(
-        length(problem$missing),
-        "I expected your `{column}` column to include the value {missing}.",
-        "I expected your `{column}` column to include the values {missing}."
-      )
-    }
-
-    problem$msg <- ngettext(
-      length(problem$missing),
-      "I expected your result to include the value {missing}.",
-      "I expected your result to include the values {missing}."
-    )
+    problem$msg <-
+      if (is_problem(problem, "column")) {
+        ngettext(
+          length(problem$missing),
+          "I expected your `{column}` column to include the value {missing}.",
+          "I expected your `{column}` column to include the values {missing}."
+        )
+      } else {
+        ngettext(
+          length(problem$missing),
+          "I expected your result to include the value {missing}.",
+          "I expected your result to include the values {missing}."
+        )
+      }
 
     problem$missing <- knitr::combine_words(md_code(problem$missing))
 

--- a/R/check_values.R
+++ b/R/check_values.R
@@ -117,15 +117,14 @@ tblcheck_message.values_problem <- function(problem, max_diffs = 3, ...) {
     max_diffs
   )
 
-  if (
-    !all(
-      vctrs::vec_equal(
-        problem$expected[seq_len(problem$n_values)],
-        problem$actual[seq_len(problem$n_values)],
-        na_equal = TRUE
-      )
+  first_n_values_are_equal <-
+    vctrs::vec_equal(
+      problem$expected[seq_len(problem$n_values)],
+      problem$actual[seq_len(problem$n_values)],
+      na_equal = TRUE
     )
-  ) {
+
+  if (!all(first_n_values_are_equal)) {
     problem$expected <- knitr::combine_words(
       md_code(problem$expected[seq_len(problem$n_values)])
     )

--- a/tests/testthat/_snaps/check_column.md
+++ b/tests/testthat/_snaps/check_column.md
@@ -34,7 +34,8 @@
       grade
     Output
       <gradethis_graded: [Incorrect]
-        I didn't expect your result to include the values `5`, `6`, and `7`.
+        I didn't expect your `a` column to include the values `5`, `6`, and
+        `7`.
       >
 
 # max_diffs modifies the number of values to print

--- a/tests/testthat/_snaps/check_values.md
+++ b/tests/testthat/_snaps/check_values.md
@@ -55,3 +55,23 @@
     Output
       <gradethis_graded: [Incorrect] Your result contains unexpected values.>
 
+# column values problem messages are created correctly
+
+    Code
+      grade_column
+    Output
+      <gradethis_graded: [Incorrect]
+        I didn't expect your `x` column to include the values `0.551`,
+        `0.879`, and `0.790`.
+      >
+
+---
+
+    Code
+      grade_tbl
+    Output
+      <gradethis_graded: [Incorrect]
+        I didn't expect your `x` column to include the values `0.551`,
+        `0.879`, and `0.790`.
+      >
+

--- a/tests/testthat/test-check_values.R
+++ b/tests/testthat/test-check_values.R
@@ -94,3 +94,27 @@ test_that("vec_grade_values() failures", {
     ignore_attr = "class"
   )
 })
+
+test_that("column values problem messages are created correctly", {
+  grade_column <- tblcheck_test_grade({
+    set.seed(4231)
+    .result <- tibble::tibble(x = c(1:5, runif(5)))
+    .solution <- tibble::tibble(x = c(1:5, runif(5)))
+    tbl_grade_column("x")
+  })
+
+  expect_snapshot(grade_column)
+
+  expect_match(grade_column$message, "your `x` column")
+
+  grade_tbl <- tblcheck_test_grade({
+    set.seed(4231)
+    .result <- tibble::tibble(x = c(1:5, runif(5)))
+    .solution <- tibble::tibble(x = c(1:5, runif(5)))
+    tbl_grade()
+  })
+
+  expect_snapshot(grade_tbl)
+
+  expect_match(grade_tbl$message, "your `x` column")
+})


### PR DESCRIPTION
Fixes a bug that caused the "I didn't expect your result" message to overwrite the "I didn't expect your ___ column" messages for values problems.


``` r
pkgload::load_all()
#> ℹ Loading tblcheck

.result <- tibble::tibble(x = c(1:5, runif(5)))
.solution <- tibble::tibble(x = c(1:5, runif(5)))
```

## Before

``` r
tbl_grade_column("x")
#> <gradethis_graded: [Incorrect]
#>   I didn't expect your result to include the values `0.2423`, `0.1420`,
#>   and `0.0605`.
#> >
```

```r
tbl_check_column("x")
#> <tblcheck problem>
#> I didn't expect your result to include the values `0.2423`, `0.1420`, and `0.0605`.
#> $ type    : chr "values"
#> $ expected: num [1:10] 1 2 3 4 5 ...
#> $ actual  : num [1:10] 1 2 3 4 5 ...
#> $ location: chr "column"
#> $ column  : chr "x"
```

## After

```r
tbl_grade_column("x")
#> <gradethis_graded: [Incorrect]
#>   I didn't expect your `x` column to include the values `0.2423`,
#>   `0.1420`, and `0.0605`.
#> >
```

```r
tbl_check_column("x")
#> <tblcheck problem>
#> I didn't expect your `x` column to include the values `0.2423`, `0.1420`, and `0.0605`.
#> $ type    : chr "values"
#> $ expected: num [1:10] 1 2 3 4 5 ...
#> $ actual  : num [1:10] 1 2 3 4 5 ...
#> $ location: chr "column"
#> $ column  : chr "x"
```