### PR TITLE
Fix #103

### DIFF
--- a/R/check_dimensions.R
+++ b/R/check_dimensions.R
@@ -217,7 +217,8 @@ tblcheck_message.length_problem <- function(problem, ...) {
   }
 
   if (!length(problem$value)) {
-    return(glue::glue_data(problem, problem$exp_msg, problem$obj_msg))
+    # remove values message: obj and exp have the same values but different length
+    problem$value_msg <- ""
   }
 
   glue::glue_data(problem, problem$exp_msg, problem$obj_msg, problem$value_msg)

--- a/R/check_dimensions.R
+++ b/R/check_dimensions.R
@@ -216,6 +216,10 @@ tblcheck_message.length_problem <- function(problem, ...) {
     }
   }
 
+  if (!length(problem$value)) {
+    return(glue::glue_data(problem, problem$exp_msg, problem$obj_msg))
+  }
+
   glue::glue_data(problem, problem$exp_msg, problem$obj_msg, problem$value_msg)
 }
 

--- a/tests/testthat/_snaps/check_dimensions.md
+++ b/tests/testthat/_snaps/check_dimensions.md
@@ -37,6 +37,15 @@
         Your result should contain 4 values, but it has 3 values.
       >
 
+---
+
+    Code
+      grade_no_unique
+    Output
+      <gradethis_graded: [Incorrect]
+        Your result should contain 4 values, but it has 3 values.
+      >
+
 # table rows
 
     Code

--- a/tests/testthat/test-check_dimensions.R
+++ b/tests/testthat/test-check_dimensions.R
@@ -66,6 +66,23 @@ test_that("vector length", {
     ),
     ignore_attr = "class"
   )
+
+  grade_no_unique <- tblcheck_test_grade({
+    .result   <- rep("a", 3)
+    .solution <- rep("a", 4)
+    vec_grade_dimensions()
+  })
+
+  expect_snapshot(grade_no_unique)
+
+  expect_equal(
+    grade_no_unique$problem,
+    problem(
+      "length",
+      rep("a", 4), rep("a", 3), expected_length = 4, actual_length = 3
+    ),
+    ignore_attr = "class"
+  )
 })
 
 test_that("table rows", {


### PR DESCRIPTION
``` r
library(tblcheck)

.result   <- c(3, 4, 3)
.solution <- c(3, 4, 3, 4, 3)
vec_grade_length()
#> <gradethis_graded: [Incorrect]
#>   Your result should contain 5 values, but it has 3 values.
#> >
```

<sup>Created on 2021-12-03 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #103.