### PR TITLE
Add `ignore_class` argument and ignore `grouped_df` if `check_groups = FALSE`

### DIFF
--- a/R/check_class.R
+++ b/R/check_class.R
@@ -11,16 +11,6 @@
 #'
 #' 1. `class`: The object does not have the expected classes
 #'
-#' @param object An object to be compared to `expected`.
-#' @param expected An object containing the expected result.
-#' @inheritParams tbl_check
-#' @inheritDotParams gradethis::fail -message
-#'
-#' @return If there are any issues, a [list] from `tbl_check_class()` and
-#'   `vec_check_class()` or a [gradethis::fail()] message from
-#'   `tbl_grade_class()` and `vec_grade_class()`.
-#'   Otherwise, invisibly returns [`NULL`].
-#' @export
 #' @examples
 #' .result <- 1:10
 #' .solution <- as.character(1:10)
@@ -36,9 +26,35 @@
 #' .solution <- dplyr::group_by(tibble::tibble(a = 1:10, b = a %% 2 == 0), b)
 #' tbl_check_class()
 #' tbl_grade_class()
+#'
+#' # Ignore the difference between tibble and data frame
+#' .result <- data.frame(a = 1:10)
+#' .solution <- tibble::tibble(a = 1:10)
+#' tbl_check_class(ignore_class = c("tbl_df", "tbl"))
+#' tbl_grade_class(ignore_class = c("tbl_df", "tbl"))
+#'
+#' # Ignore the difference between integer and double
+#' .result <- 1L
+#' .solution <- 1
+#' vec_check_class(ignore_class = c("integer", "numeric"))
+#' vec_grade_class(ignore_class = c("integer", "numeric"))
+#'
+#' @param object An object to be compared to `expected`.
+#' @param expected An object containing the expected result.
+#' @param ignore_class `[character()]`\cr A vector of classes to ignore when
+#'   finding differences between `object` and `expected`. See examples.
+#' @inheritParams tbl_check
+#' @inheritDotParams gradethis::fail -message
+#'
+#' @return If there are any issues, a [list] from `tbl_check_class()` and
+#'   `vec_check_class()` or a [gradethis::fail()] message from
+#'   `tbl_grade_class()` and `vec_grade_class()`.
+#'   Otherwise, invisibly returns [`NULL`].
+#' @export
 tbl_check_class <- function(
   object = .result,
   expected = .solution,
+  ignore_class = NULL,
   env = parent.frame()
 ) {
   if (inherits(object, ".result")) {
@@ -51,7 +67,10 @@ tbl_check_class <- function(
   obj_class <- class(object)
   exp_class <- class(expected)
 
-  if (!identical(obj_class, exp_class)) {
+  obj_class_ignored <- setdiff(obj_class, ignore_class)
+  exp_class_ignored <- setdiff(exp_class, ignore_class)
+
+  if (!identical(obj_class_ignored, exp_class_ignored)) {
     problem(
       "class",
       exp_class,
@@ -73,11 +92,12 @@ vec_check_class <- tbl_check_class
 tbl_grade_class <- function(
   object = .result,
   expected = .solution,
+  ignore_class = NULL,
   env = parent.frame(),
   ...
 ) {
   tblcheck_grade(
-    tbl_check_class(object, expected, env),
+    tbl_check_class(object, expected, ignore_class, env),
     env = env,
     ...
   )

--- a/R/check_column.R
+++ b/R/check_column.R
@@ -33,6 +33,7 @@
 #'   print. Defaults to 3.
 #' @param check_class `[logical(1)]`\cr Whether to check that `column` has the
 #'   same class in `object` and `expected`.
+#' @inheritParams tbl_check_class
 #' @param check_length `[logical(1)]`\cr Whether to check that `column` has the
 #'   same length in `object` and `expected`.
 #' @param check_values `[logical(1)]`\cr Whether to check that `column` has the
@@ -71,6 +72,7 @@ tbl_check_column <- function(
   object = .result,
   expected = .solution,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = FALSE,
@@ -109,6 +111,7 @@ tbl_check_column <- function(
       object[[column]],
       expected[[column]],
       check_class = check_class,
+      ignore_class = ignore_class,
       check_length = check_length,
       check_values = check_values,
       check_names = check_names
@@ -126,6 +129,7 @@ tbl_grade_column <- function(
   expected = .solution,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = FALSE,
@@ -138,6 +142,7 @@ tbl_grade_column <- function(
       object = object,
       expected = expected,
       check_class = check_class,
+      ignore_class = ignore_class,
       check_length = check_length,
       check_values = check_values,
       check_names = check_names,

--- a/R/check_table.R
+++ b/R/check_table.R
@@ -41,6 +41,7 @@
 #'   Defaults to 3.
 #' @param check_class `[logical(1)]`\cr Whether to check that `object` and
 #'   `expected` have the same classes with [tbl_check_class()].
+#' @inheritParams tbl_check_class
 #' @param check_names `[logical(1)]`\cr Whether to check that `object` and
 #'   `expected` have the same column names with [tbl_check_names()].
 #' @param check_column_order `[logical(1)]`\cr Whether to check that the columns
@@ -105,6 +106,7 @@ tbl_check <- function(
   expected = .solution,
   cols = NULL,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,
@@ -135,7 +137,7 @@ tbl_check <- function(
   # check table class ----
   if (check_class) {
     return_if_problem(
-      tbl_check_class(object, expected),
+      tbl_check_class(object, expected, ignore_class),
       prefix = "table"
     )
   } else (
@@ -207,6 +209,7 @@ tbl_grade <- function(
   cols = NULL,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,
@@ -223,6 +226,7 @@ tbl_grade <- function(
       expected = expected,
       cols = !!rlang::enexpr(cols),
       check_class = check_class,
+      ignore_class = ignore_class,
       check_names = check_names,
       check_column_order = check_column_order,
       check_dimensions = check_dimensions,

--- a/R/check_table.R
+++ b/R/check_table.R
@@ -101,6 +101,12 @@
 #' tbl_grade()
 #' tbl_grade(max_diffs = 5)
 #' tbl_grade(max_diffs = Inf)
+#'
+#' .result <- tibble::tibble(a = 1:10, b = rep(1:2, 5))
+#' .solution <- dplyr::group_by(tibble::tibble(a = 1:10, b = rep(1:2, 5)), b)
+#' tbl_check()
+#' tbl_grade()
+#' tbl_grade(check_groups = FALSE)
 tbl_check <- function(
   object = .result,
   expected = .solution,
@@ -136,6 +142,10 @@ tbl_check <- function(
 
   # check table class ----
   if (check_class) {
+    if (!check_groups) {
+      ignore_class <- c(ignore_class, "grouped_df")
+    }
+
     return_if_problem(
       tbl_check_class(object, expected, ignore_class),
       prefix = "table"

--- a/R/check_vector.R
+++ b/R/check_vector.R
@@ -30,6 +30,7 @@
 #'   print. Defaults to 3.
 #' @param check_class `[logical(1)]`\cr Whether to check that `object` and
 #'   `expected` have the same classes.
+#' @inheritParams tbl_check_class
 #' @param check_length `[logical(1)]`\cr Whether to check that `object` and
 #'   `expected` have the same length.
 #' @param check_levels `[logical(1)]`\cr Whether to check that `object` and
@@ -74,6 +75,7 @@ vec_check <- function(
   object = .result,
   expected = .solution,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_levels = TRUE,
   check_values = TRUE,
@@ -96,7 +98,7 @@ vec_check <- function(
 
   if (check_class) {
     return_if_problem(
-      vec_check_class(object, expected),
+      vec_check_class(object, expected, ignore_class),
       prefix = "vector"
     )
   }
@@ -137,6 +139,7 @@ vec_grade <- function(
   expected = .solution,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = TRUE,
@@ -148,6 +151,7 @@ vec_grade <- function(
       object = object,
       expected = expected,
       check_class = check_class,
+      ignore_class = ignore_class,
       check_length = check_length,
       check_values = check_values,
       check_names = check_names,

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -75,6 +75,7 @@ grade_this_table <- function(
   max_diffs = 3,
   cols = NULL,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,

--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -140,6 +140,7 @@ grade_this_vector <- function(
   # all the arguments from tbl_grade_table() except object/expected
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = TRUE,

--- a/man/grade_this_table.Rd
+++ b/man/grade_this_table.Rd
@@ -13,6 +13,7 @@ grade_this_table(
   max_diffs = 3,
   cols = NULL,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,
@@ -60,6 +61,9 @@ will be ignored. If \code{\link{NULL}}, the default, all columns will be checked
 
 \item{check_class}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same classes with \code{\link[=tbl_check_class]{tbl_check_class()}}.}
+
+\item{ignore_class}{\verb{[character()]}\cr A vector of classes to ignore when
+finding differences between \code{object} and \code{expected}. See examples.}
 
 \item{check_names}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same column names with \code{\link[=tbl_check_names]{tbl_check_names()}}.}

--- a/man/tbl_check.Rd
+++ b/man/tbl_check.Rd
@@ -10,6 +10,7 @@ tbl_check(
   expected = .solution,
   cols = NULL,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,
@@ -26,6 +27,7 @@ tbl_grade(
   cols = NULL,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_names = TRUE,
   check_column_order = FALSE,
   check_dimensions = TRUE,
@@ -48,6 +50,9 @@ will be ignored. If \code{\link{NULL}}, the default, all columns will be checked
 
 \item{check_class}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same classes with \code{\link[=tbl_check_class]{tbl_check_class()}}.}
+
+\item{ignore_class}{\verb{[character()]}\cr A vector of classes to ignore when
+finding differences between \code{object} and \code{expected}. See examples.}
 
 \item{check_names}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same column names with \code{\link[=tbl_check_names]{tbl_check_names()}}.}

--- a/man/tbl_check.Rd
+++ b/man/tbl_check.Rd
@@ -174,4 +174,10 @@ tbl_check()
 tbl_grade()
 tbl_grade(max_diffs = 5)
 tbl_grade(max_diffs = Inf)
+
+.result <- tibble::tibble(a = 1:10, b = rep(1:2, 5))
+.solution <- dplyr::group_by(tibble::tibble(a = 1:10, b = rep(1:2, 5)), b)
+tbl_check()
+tbl_grade()
+tbl_grade(check_groups = FALSE)
 }

--- a/man/tbl_check_class.Rd
+++ b/man/tbl_check_class.Rd
@@ -7,13 +7,24 @@
 \alias{vec_grade_class}
 \title{Checks that two objects have the same classes}
 \usage{
-tbl_check_class(object = .result, expected = .solution, env = parent.frame())
+tbl_check_class(
+  object = .result,
+  expected = .solution,
+  ignore_class = NULL,
+  env = parent.frame()
+)
 
-vec_check_class(object = .result, expected = .solution, env = parent.frame())
+vec_check_class(
+  object = .result,
+  expected = .solution,
+  ignore_class = NULL,
+  env = parent.frame()
+)
 
 tbl_grade_class(
   object = .result,
   expected = .solution,
+  ignore_class = NULL,
   env = parent.frame(),
   ...
 )
@@ -21,6 +32,7 @@ tbl_grade_class(
 vec_grade_class(
   object = .result,
   expected = .solution,
+  ignore_class = NULL,
   env = parent.frame(),
   ...
 )
@@ -29,6 +41,9 @@ vec_grade_class(
 \item{object}{An object to be compared to \code{expected}.}
 
 \item{expected}{An object containing the expected result.}
+
+\item{ignore_class}{\verb{[character()]}\cr A vector of classes to ignore when
+finding differences between \code{object} and \code{expected}. See examples.}
 
 \item{env}{The environment in which to find \code{.result} and \code{.solution}.}
 
@@ -83,4 +98,17 @@ tbl_grade_class()
 .solution <- dplyr::group_by(tibble::tibble(a = 1:10, b = a \%\% 2 == 0), b)
 tbl_check_class()
 tbl_grade_class()
+
+# Ignore the difference between tibble and data frame
+.result <- data.frame(a = 1:10)
+.solution <- tibble::tibble(a = 1:10)
+tbl_check_class(ignore_class = c("tbl_df", "tbl"))
+tbl_grade_class(ignore_class = c("tbl_df", "tbl"))
+
+# Ignore the difference between integer and double
+.result <- 1L
+.solution <- 1
+vec_check_class(ignore_class = c("integer", "numeric"))
+vec_grade_class(ignore_class = c("integer", "numeric"))
+
 }

--- a/man/tbl_check_column.Rd
+++ b/man/tbl_check_column.Rd
@@ -10,6 +10,7 @@ tbl_check_column(
   object = .result,
   expected = .solution,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = FALSE,
@@ -22,6 +23,7 @@ tbl_grade_column(
   expected = .solution,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = FALSE,
@@ -38,6 +40,9 @@ tbl_grade_column(
 
 \item{check_class}{\verb{[logical(1)]}\cr Whether to check that \code{column} has the
 same class in \code{object} and \code{expected}.}
+
+\item{ignore_class}{\verb{[character()]}\cr A vector of classes to ignore when
+finding differences between \code{object} and \code{expected}. See examples.}
 
 \item{check_length}{\verb{[logical(1)]}\cr Whether to check that \code{column} has the
 same length in \code{object} and \code{expected}.}

--- a/man/vec_check.Rd
+++ b/man/vec_check.Rd
@@ -9,6 +9,7 @@ vec_check(
   object = .result,
   expected = .solution,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_levels = TRUE,
   check_values = TRUE,
@@ -21,6 +22,7 @@ vec_grade(
   expected = .solution,
   max_diffs = 3,
   check_class = TRUE,
+  ignore_class = NULL,
   check_length = TRUE,
   check_values = TRUE,
   check_names = TRUE,
@@ -35,6 +37,9 @@ vec_grade(
 
 \item{check_class}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same classes.}
+
+\item{ignore_class}{\verb{[character()]}\cr A vector of classes to ignore when
+finding differences between \code{object} and \code{expected}. See examples.}
 
 \item{check_length}{\verb{[logical(1)]}\cr Whether to check that \code{object} and
 \code{expected} have the same length.}

--- a/tests/testthat/_snaps/check_class.md
+++ b/tests/testthat/_snaps/check_class.md
@@ -38,7 +38,7 @@
         it is a vector of text (class `character`).
       >
 
-# tbl_grade_class() does not ignore formerly inconsequential mismatches
+# tbl_grade_class() ignore classes
 
     Code
       grade_int_dbl
@@ -66,6 +66,16 @@
       <gradethis_graded: [Incorrect]
         Your result should be a vector of date-times (class `POSIXlt`), but
         it is a vector of date-times (class `POSIXct`).
+      >
+
+---
+
+    Code
+      grade_tbl_df
+    Output
+      <gradethis_graded: [Incorrect]
+        Your result should be a tibble (class `tbl_df`), but it is a data
+        frame (class `data.frame`).
       >
 
 # tbl_grade_class() with multiple classes

--- a/tests/testthat/_snaps/check_column.md
+++ b/tests/testthat/_snaps/check_column.md
@@ -8,6 +8,16 @@
         it is a vector of text (class `character`).
       >
 
+---
+
+    Code
+      grade_int
+    Output
+      <gradethis_graded: [Incorrect]
+        Your `a` column should be a vector of integers (class `integer`), but
+        it is a vector of numbers (class `numeric`).
+      >
+
 # tbl_grade_column() checks the first three values
 
     Code

--- a/tests/testthat/_snaps/check_vector.md
+++ b/tests/testthat/_snaps/check_vector.md
@@ -8,6 +8,16 @@
         is a vector of text (class `character`).
       >
 
+---
+
+    Code
+      grade_int
+    Output
+      <gradethis_graded: [Incorrect]
+        Your result should be a vector of integers (class `integer`), but it
+        is a vector of numbers (class `numeric`).
+      >
+
 # vec_grade() checks the first three values
 
     Code

--- a/tests/testthat/test-check_class.R
+++ b/tests/testthat/test-check_class.R
@@ -80,7 +80,7 @@ test_that("tbl_grade_class()", {
   )
 })
 
-test_that("tbl_grade_class() does not ignore formerly inconsequential mismatches", {
+test_that("tbl_grade_class() ignore classes", {
   grade_int_dbl <-
     tblcheck_test_grade({
       .result   <- 1L
@@ -100,6 +100,15 @@ test_that("tbl_grade_class() does not ignore formerly inconsequential mismatches
       actual_length = 1
     )
   )
+
+  grade_int_dbl_ignore <-
+    tblcheck_test_grade({
+      .result   <- 1L
+      .solution <- 1
+      tbl_grade_class(ignore_class = c("integer", "numeric"))
+    })
+
+  expect_null(grade_int_dbl_ignore)
 
   grade_glue_chr <-
     tblcheck_test_grade({
@@ -121,6 +130,15 @@ test_that("tbl_grade_class() does not ignore formerly inconsequential mismatches
     )
   )
 
+  grade_glue_chr_ignore <-
+    tblcheck_test_grade({
+      .result   <- glue::glue("x")
+      .solution <- "x"
+      tbl_grade_class(ignore_class = "glue")
+    })
+
+  expect_null(grade_glue_chr_ignore)
+
   grade_posix_ct_lt <-
     tblcheck_test_grade({
       .result   <- as.POSIXct(c("2021-07-29 15:18:00", "1996-03-05 12:00:00"))
@@ -140,6 +158,44 @@ test_that("tbl_grade_class() does not ignore formerly inconsequential mismatches
       actual_length = 2
     )
   )
+
+  grade_posix_ct_lt_ignore <-
+    tblcheck_test_grade({
+      .result   <- as.POSIXct(c("2021-07-29 15:18:00", "1996-03-05 12:00:00"))
+      .solution <- as.POSIXlt(c("2021-07-29 15:18:00", "1996-03-05 12:00:00"))
+      tbl_grade_class(ignore_class = c("POSIXct", "POSIXlt"))
+    })
+
+  expect_null(grade_posix_ct_lt_ignore)
+
+  grade_tbl_df <-
+    tblcheck_test_grade({
+      .result   <- data.frame(a = 1, b = 2)
+      .solution <- tibble::tibble(a = 1, b = 2)
+      tbl_grade_class()
+    })
+
+  expect_snapshot(grade_tbl_df)
+
+  expect_equal(
+    grade_tbl_df$problem,
+    problem(
+      type     = "class",
+      expected = c("tbl_df", "tbl", "data.frame"),
+      actual   = c("data.frame"),
+      expected_length = 2,
+      actual_length = 2
+    )
+  )
+
+  grade_tbl_df_ignore <-
+    tblcheck_test_grade({
+      .result   <- data.frame(a = 1, b = 2)
+      .solution <- tibble::tibble(a = 1, b = 2)
+      tbl_grade_class(ignore_class = c("tbl_df", "tbl"))
+    })
+
+  expect_null(grade_tbl_df_ignore)
 })
 
 test_that("tbl_grade_class() with multiple classes", {

--- a/tests/testthat/test-check_column.R
+++ b/tests/testthat/test-check_column.R
@@ -20,6 +20,38 @@ test_that("tbl_grade_column() checks classes", {
     ),
     ignore_attr = "class"
   )
+
+  grade_int <- tblcheck_test_grade({
+    .result   <- tibble::tibble(a = c(1, 2, 3))
+    .solution <- tibble::tibble(a = 1:3)
+    tbl_grade_column("a", .result, .solution)
+  })
+
+  expect_snapshot(grade_int)
+
+  expect_equal(
+    grade_int$problem,
+    problem(
+      "class",
+      "integer",
+      "numeric",
+      expected_length = 3,
+      actual_length = 3,
+      location = "column",
+      column = "a"
+    ),
+    ignore_attr = "class"
+  )
+
+  grade_int_ignore <- tblcheck_test_grade({
+    .result   <- tibble::tibble(a = c(1, 2, 3))
+    .solution <- tibble::tibble(a = 1:3)
+    tbl_grade_column(
+      "a", .result, .solution, ignore_class = c("integer", "numeric")
+    )
+  })
+
+  expect_null(grade_int_ignore)
 })
 
 test_that("tbl_grade_column() checks the first three values", {

--- a/tests/testthat/test-check_table.R
+++ b/tests/testthat/test-check_table.R
@@ -21,6 +21,15 @@ test_that("tbl_grade() class", {
     ignore_attr = "class"
   )
 
+  grade_tbl_class_df_ignore <-
+    tblcheck_test_grade({
+      .result   <- data.frame(a = 1:10, b = 1:10)
+      .solution <- tibble::tibble(a = 1:10, b = 1:10)
+      tbl_grade(ignore_class = c("tbl_df", "tbl"))
+    })
+
+  expect_null(grade_tbl_class_df_ignore)
+
   grade_tbl_class_grouped <-
     tblcheck_test_grade({
       .result   <- tibble::tibble(a = 1:10, b = a)

--- a/tests/testthat/test-check_table.R
+++ b/tests/testthat/test-check_table.R
@@ -52,6 +52,15 @@ test_that("tbl_grade() class", {
     ignore_attr = "class"
   )
 
+  grade_tbl_class_grouped_ignore <-
+    tblcheck_test_grade({
+      .result   <- tibble::tibble(a = 1:10, b = a)
+      .solution <- dplyr::group_by(tibble::tibble(a = 1:10, b = a), a)
+      tbl_grade(check_groups = FALSE)
+    })
+
+  expect_null(grade_tbl_class_grouped_ignore)
+
   grade_tbl_class_rowwise <-
     tblcheck_test_grade({
       .result   <- dplyr::rowwise(tibble::tibble(a = 1:10, b = a))

--- a/tests/testthat/test-check_vector.R
+++ b/tests/testthat/test-check_vector.R
@@ -19,6 +19,35 @@ test_that("vec_grade() checks classes", {
     ),
     ignore_attr = "class"
   )
+
+  grade_int <- tblcheck_test_grade({
+    .result   <- c(1, 2, 3)
+    .solution <- 1:3
+    vec_grade()
+  })
+
+  expect_snapshot(grade_int)
+
+  expect_equal(
+    grade_int$problem,
+    problem(
+      "class",
+      "integer",
+      "numeric",
+      expected_length = 3,
+      actual_length = 3,
+      location = "vector"
+    ),
+    ignore_attr = "class"
+  )
+
+  grade_int_ignore <- tblcheck_test_grade({
+    .result   <- c(1, 2, 3)
+    .solution <- 1:3
+    vec_grade(ignore_class = c("integer", "numeric"))
+  })
+
+  expect_null(grade_int_ignore)
 })
 
 test_that("vec_grade() checks the first three values", {


### PR DESCRIPTION
- Adds argument `ignore_groups` to `*_class()` check and `*_table()`, `*_vector()`, and `*_column()` checks, specifying class differences to ignore.
- Table checking now ignores `grouped_df` class if `check_groups = FALSE`.

``` r
library(dplyr)
library(tblcheck)

.result   <- data.frame(a = 1, b = 2)
.solution <- tibble(a = 1, b = 2)

tbl_check_class(ignore_class = c("tbl_df", "tbl"))
# No output

.result   <- tibble(a = 1, b = 2)
.solution <- tibble(a = 1, b = 2) %>% group_by(b)

tbl_check(check_groups = FALSE)
# No output
```

<sup>Created on 2022-02-04 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #108.