### PR TITLE
Fix #118

### DIFF
--- a/DESCRIPTION
+++ b/DESCRIPTION
@@ -46,4 +46,4 @@ Config/Needs/website: pkgdown, tidyverse/tidytemplate, forcats, stringr
 Config/testthat/edition: 3
 Encoding: UTF-8
 Roxygen: list(markdown = TRUE)
-RoxygenNote: 7.1.2
+RoxygenNote: 7.2.1

--- a/R/check_class.R
+++ b/R/check_class.R
@@ -157,18 +157,15 @@ tblcheck_message.class_problem <- function(problem, ...) {
 }
 
 hinted_class_message <- function(obj_class, exp_class) {
-  list <- hinted_class_message_list()
-
-  for (i in seq_along(list)) {
+  for (query in hinted_class_message_list()) {
     if (
-      all(list[[i]]$obj_class %in% obj_class) &&
-        all(list[[i]]$exp_class %in% exp_class)
+      # If `query$obj_class()` or `query$exp_class()` are empty,
+      # any class will match because `all(logical(0)) == TRUE`
+      all(query$obj_class %in% obj_class) && all(query$exp_class %in% exp_class)
     ) {
-      return(list[[i]]$message)
+      return(query$message)
     }
   }
-
-  invisible()
 }
 
 hinted_class_message_list <- function() {

--- a/R/check_class.R
+++ b/R/check_class.R
@@ -177,19 +177,23 @@ hinted_class_message_list <- function() {
       message   = "Your table is a rowwise data frame, but I was expecting it to be grouped. Maybe you need to use `group_by()`?"
     ),
     list(
+      obj_class = "data.frame",
       exp_class = "grouped_df",
       message   = "Your table isn't a grouped data frame, but I was expecting it to be grouped. Maybe you need to use `group_by()`?"
     ),
     list(
       obj_class = "grouped_df",
+      exp_class = "data.frame",
       message   = "Your table is a grouped data frame, but I wasn't expecting it to be grouped. Maybe you need to use `ungroup()`?"
     ),
     list(
+      obj_class = "data.frame",
       exp_class = "rowwise_df",
       message   = "Your table isn't a rowwise data frame, but I was expecting it to be rowwise. Maybe you need to use `rowwise()`?"
     ),
     list(
       obj_class = "rowwise_df",
+      exp_class = "data.frame",
       message   = "Your table is a rowwise data frame, but I wasn't expecting it to be rowwise. Maybe you need to use `ungroup()`?"
     )
   )

--- a/R/check_class.R
+++ b/R/check_class.R
@@ -280,6 +280,14 @@ friendly_class_list <- function() {
       single   = "a tibble (class `tbl_df`)"
     ),
     list(
+      class    = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+      single   = "a grouped tibble (class `grouped_df`)"
+    ),
+    list(
+      class    = c("rowwise_df", "tbl_df", "tbl", "data.frame"),
+      single   = "a rowwise tibble (class `rowwise_df`)"
+    ),
+    list(
       class    = "data.frame",
       single   = "a data frame (class `data.frame`)"
     ),

--- a/man/grade_this_table.Rd
+++ b/man/grade_this_table.Rd
@@ -104,16 +104,16 @@ column has the same values in \code{object} and \code{expected}.}
 
 \item{hint}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
 
 \item{encourage}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
 
 \item{pass.praise}{Logical \code{TRUE} or \code{FALSE} to determine whether a praising
-phrase should be automatically prepended to any \code{\link[gradethis:graded]{pass()}} or
+phrase should be automatically prepended to any \code{\link[gradethis:pass]{pass()}} or
 \code{\link[gradethis:pass_if_equal]{pass_if_equal()}} messages. Sets the \code{gradethis.pass.praise} option.}
 }
 \value{

--- a/man/grade_this_vector.Rd
+++ b/man/grade_this_vector.Rd
@@ -27,14 +27,7 @@ grade_this_vector(
 their \code{.result} matches the exercise \code{.solution}, if \code{pass_if_equal} is
 \code{TRUE}.}
 
-\item{pre_check}{\verb{[expression]}\cr Code to run before or after the
-table or vector grading is performed. The pre check runs before calling
-\code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} so that you can modify or adjust the student's
-\code{.result} or the \code{.solution} if there are parts of either that need to be
-ignored. These arguments can also be used in conjunction with the
-\code{pass_if_equal} option when the grading requirements are more involved.}
-
-\item{post_check}{\verb{[expression]}\cr Code to run before or after the
+\item{pre_check, post_check}{\verb{[expression]}\cr Code to run before or after the
 table or vector grading is performed. The pre check runs before calling
 \code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} so that you can modify or adjust the student's
 \code{.result} or the \code{.solution} if there are parts of either that need to be
@@ -83,16 +76,16 @@ a \code{class} problem will never be returned.}
 
 \item{hint}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
 
 \item{encourage}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
 
 \item{pass.praise}{Logical \code{TRUE} or \code{FALSE} to determine whether a praising
-phrase should be automatically prepended to any \code{\link[gradethis:graded]{pass()}} or
+phrase should be automatically prepended to any \code{\link[gradethis:pass]{pass()}} or
 \code{\link[gradethis:pass_if_equal]{pass_if_equal()}} messages. Sets the \code{gradethis.pass.praise} option.}
 }
 \value{

--- a/man/tbl_check.Rd
+++ b/man/tbl_check.Rd
@@ -106,11 +106,11 @@ Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_class.Rd
+++ b/man/tbl_check_class.Rd
@@ -61,11 +61,11 @@ a \code{class} problem will never be returned.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_column.Rd
+++ b/man/tbl_check_column.Rd
@@ -78,11 +78,11 @@ print. Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_dimensions.Rd
+++ b/man/tbl_check_dimensions.Rd
@@ -69,11 +69,11 @@ vec_grade_length(
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_groups.Rd
+++ b/man/tbl_check_groups.Rd
@@ -31,11 +31,11 @@ Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_is_table.Rd
+++ b/man/tbl_check_is_table.Rd
@@ -19,11 +19,11 @@ tbl_grade_is_table(object = .result, env = parent.frame(), ...)
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tbl_check_names.Rd
+++ b/man/tbl_check_names.Rd
@@ -58,11 +58,11 @@ Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/tblcheck_grade.Rd
+++ b/man/tblcheck_grade.Rd
@@ -32,11 +32,11 @@ Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/vec_check.Rd
+++ b/man/vec_check.Rd
@@ -77,11 +77,11 @@ print. Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/vec_check_levels.Rd
+++ b/man/vec_check_levels.Rd
@@ -31,11 +31,11 @@ Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/man/vec_check_values.Rd
+++ b/man/vec_check_values.Rd
@@ -39,11 +39,11 @@ print. Defaults to 3.}
   \describe{
     \item{\code{hint}}{Include a code feedback hint with the failing message? This
 argument only applies to \code{fail()} and \code{fail_if_equal()} and the message is
-added using the default options of \code{\link[gradethis:code_feedback]{give_code_feedback()}} and
-\code{\link[gradethis:code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
+added using the default options of \code{\link[gradethis:give_code_feedback]{give_code_feedback()}} and
+\code{\link[gradethis:maybe_code_feedback]{maybe_code_feedback()}}. The default value of \code{hint} can be set using
 \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.hint} option.}
     \item{\code{encourage}}{Include a random encouraging phrase with
-\code{\link[gradethis:praise]{random_encouragement()}}? The default value of \code{encourage} can be set
+\code{\link[gradethis:random_encouragement]{random_encouragement()}}? The default value of \code{encourage} can be set
 using \code{\link[gradethis:gradethis_setup]{gradethis_setup()}} or the \code{gradethis.fail.encourage} option.}
   }}
 }

--- a/tests/testthat/_snaps/check_class.md
+++ b/tests/testthat/_snaps/check_class.md
@@ -108,3 +108,43 @@
         object with classes `test`, `class`, and `integer`.
       >
 
+# tbl_grade_class() with hinted messages
+
+    Code
+      grade_ungrouped
+    Output
+      <gradethis_graded: [Incorrect]
+        Your table isn't a grouped data frame, but I was expecting it to be
+        grouped. Maybe you need to use `group_by()`?
+      >
+
+---
+
+    Code
+      grade_grouped
+    Output
+      <gradethis_graded: [Incorrect]
+        Your table is a grouped data frame, but I wasn't expecting it to be
+        grouped. Maybe you need to use `ungroup()`?
+      >
+
+---
+
+    Code
+      grade_ungrouped_int
+    Output
+      <gradethis_graded: [Incorrect]
+        Your result should be a grouped tibble (class `grouped_df`), but it
+        is a vector of integers (class `integer`).
+      >
+
+---
+
+    Code
+      grade_unrowwise_int
+    Output
+      <gradethis_graded: [Incorrect]
+        Your result should be a rowwise tibble (class `rowwise_df`), but it
+        is a vector of integers (class `integer`).
+      >
+

--- a/tests/testthat/test-check_class.R
+++ b/tests/testthat/test-check_class.R
@@ -318,3 +318,85 @@ test_that("tbl_grade_class() with classes in different orders", {
 
   expect_null(grade)
 })
+
+test_that("tbl_grade_class() with hinted messages", {
+  grade_ungrouped <- tblcheck_test_grade({
+    .result   <- tibble::tibble(a = letters[1:3], b = a)
+    .solution <- dplyr::group_by(tibble::tibble(a = letters[1:3], b = a), b)
+    tbl_grade_class()
+  })
+
+  expect_snapshot(grade_ungrouped)
+
+  expect_equal(
+    grade_ungrouped$problem,
+    problem(
+      "class",
+      expected = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+      actual = c("tbl_df", "tbl", "data.frame"),
+      expected_length = 2,
+      actual_length = 2
+    ),
+    ignore_attr = "class"
+  )
+
+  grade_grouped <- tblcheck_test_grade({
+    .result   <- dplyr::group_by(tibble::tibble(a = letters[1:3], b = a), b)
+    .solution <- tibble::tibble(a = letters[1:3], b = a)
+    tbl_grade_class()
+  })
+
+  expect_snapshot(grade_grouped)
+
+  expect_equal(
+    grade_grouped$problem,
+    problem(
+      "class",
+      expected = c("tbl_df", "tbl", "data.frame"),
+      actual = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+      expected_length = 2,
+      actual_length = 2
+    ),
+    ignore_attr = "class"
+  )
+
+  grade_ungrouped_int <- tblcheck_test_grade({
+    .result   <- 1:2
+    .solution <- dplyr::group_by(tibble::tibble(a = letters[1:3], b = a), b)
+    tbl_grade_class()
+  })
+
+  expect_snapshot(grade_ungrouped_int)
+
+  expect_equal(
+    grade_ungrouped_int$problem,
+    problem(
+      "class",
+      expected = c("grouped_df", "tbl_df", "tbl", "data.frame"),
+      actual = "integer",
+      expected_length = 2,
+      actual_length = 2
+    ),
+    ignore_attr = "class"
+  )
+
+  grade_unrowwise_int <- tblcheck_test_grade({
+    .result   <- 1:2
+    .solution <- dplyr::rowwise(tibble::tibble(a = letters[1:3], b = a))
+    tbl_grade_class()
+  })
+
+  expect_snapshot(grade_unrowwise_int)
+
+  expect_equal(
+    grade_unrowwise_int$problem,
+    problem(
+      "class",
+      expected = c("rowwise_df", "tbl_df", "tbl", "data.frame"),
+      actual = "integer",
+      expected_length = 2,
+      actual_length = 2
+    ),
+    ignore_attr = "class"
+  )
+})


### PR DESCRIPTION
`tbl_grade_class()` now only suggests using functions like `group_by()`, `rowwise()` or `ungroup()` if both `.result` and `.solution` are at least data frames.

``` r
library(dplyr)
library(tblcheck)

.result <- 1:2
.solution <- tibble(a = 1, b = 2) %>% group_by(b)
tbl_grade_class()
#> <gradethis_graded: [Incorrect]
#>   Your result should be a grouped tibble (class `grouped_df`), but it
#>   is a vector of integers (class `integer`).
#> >

.result <- tibble(a = 1, b = 2)
.solution <- tibble(a = 1, b = 2) %>% group_by(b)
tbl_grade_class()
#> <gradethis_graded: [Incorrect]
#>   Your table isn't a grouped data frame, but I was expecting it to be
#>   grouped. Maybe you need to use `group_by()`?
#> >
```

<sup>Created on 2022-08-08 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #118.