### PR TITLE
Don't call non-vectors "vectors"

### DIFF
--- a/R/check_class.R
+++ b/R/check_class.R
@@ -215,18 +215,10 @@ friendly_class <- function(class, length) {
   class_str <- knitr::combine_words(md_code(class))
 
   glue::glue(
-    ifelse(
-      length > 1,
-      ngettext(
-        length(class),
-        "a vector with class {class_str}",
-        "a vector with classes {class_str}"
-      ),
-      ngettext(
-        length(class),
-        "an object with class {class_str}",
-        "an object with classes {class_str}"
-      )
+    ngettext(
+      length(class),
+      "an object with class {class_str}",
+      "an object with classes {class_str}"
     )
   )
 }

--- a/R/check_class.R
+++ b/R/check_class.R
@@ -164,7 +164,7 @@ hinted_class_message <- function(obj_class, exp_class) {
       # that we should ignore the class for that object. The use of `all()`
       # accounts for both situations since `all(logical(0))` returns `TRUE`.
       all(hinted_class$obj_class %in% obj_class) &&
-      all(hinted_class$exp_class %in% exp_class)
+        all(hinted_class$exp_class %in% exp_class)
     ) {
       return(hinted_class$message)
     }


### PR DESCRIPTION
Remove messages with "vector" from the fallback method in `friendly_class()`.
Now if the method falls back, it will always describe the object as an "object".
All atomic vectors types already have an associated friendly class message, so they will still be correctly described as vectors.

``` r
.result <- 1:2
.solution <- lm(mpg ~ wt, data = mtcars)
tbl_grade_class()
#> <gradethis_graded: [Incorrect]
#>   Your result should be an object with class `lm`, but it is a vector
#>   of integers (class `integer`).
#> >

.result <- 1:2
.solution <- c("1", "2")
tbl_grade_class()
#> <gradethis_graded: [Incorrect]
#>   Your result should be a vector of text (class `character`), but it is
#>   a vector of integers (class `integer`).
#> >
```

<sup>Created on 2022-08-09 by the [reprex package](https://reprex.tidyverse.org) (v2.0.1)</sup>

Closes #120.