### PR TITLE
Set `pass_if_equal = FALSE` as default in `grade_this_table()`

### DIFF
--- a/R/grade_this.R
+++ b/R/grade_this.R
@@ -32,8 +32,9 @@
 #'   `.result` or the `.solution` if there are parts of either that need to be
 #'   ignored. These arguments can also be used in conjunction with the
 #'   `pass_if_equal` option when the grading requirements are more involved.
-#' @param pass_if_equal `[logical(1)]`\cr When `TRUE` (default), the `.result`
-#'   is compared to the `.solution` with [gradethis::pass_if_equal()] after the
+#' @param pass_if_equal `[logical(1)]`\cr When `TRUE` (default for
+#'   `grade_this_vector()` but not `grade_this_table()`), the `.result` is
+#'   compared to the `.solution` with [gradethis::pass_if_equal()] after the
 #'   _pre check_ and before calling the \pkg{tblcheck} grading function.
 #' @inheritParams gradethis::fail
 #' @inheritParams gradethis::gradethis_setup
@@ -66,7 +67,7 @@ grade_this_table <- function(
 	correct = NULL,
 	pre_check = NULL,
 	post_check = NULL,
-	pass_if_equal = TRUE,
+	pass_if_equal = FALSE,
 	...,
 	# all the arguments from tbl_grade_table() except object/expected
 	max_diffs = 3,

--- a/man/grade_this_table.Rd
+++ b/man/grade_this_table.Rd
@@ -8,7 +8,7 @@ grade_this_table(
   correct = NULL,
   pre_check = NULL,
   post_check = NULL,
-  pass_if_equal = TRUE,
+  pass_if_equal = FALSE,
   ...,
   max_diffs = 3,
   cols = NULL,
@@ -39,8 +39,9 @@ table or vector grading is performed. The pre check runs before calling
 ignored. These arguments can also be used in conjunction with the
 \code{pass_if_equal} option when the grading requirements are more involved.}
 
-\item{pass_if_equal}{\verb{[logical(1)]}\cr When \code{TRUE} (default), the \code{.result}
-is compared to the \code{.solution} with \code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} after the
+\item{pass_if_equal}{\verb{[logical(1)]}\cr When \code{TRUE} (default for
+\code{grade_this_vector()} but not \code{grade_this_table()}), the \code{.result} is
+compared to the \code{.solution} with \code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} after the
 \emph{pre check} and before calling the \pkg{tblcheck} grading function.}
 
 \item{...}{Additional arguments passed to \code{graded()} or additional data to be

--- a/man/grade_this_vector.Rd
+++ b/man/grade_this_vector.Rd
@@ -34,8 +34,9 @@ table or vector grading is performed. The pre check runs before calling
 ignored. These arguments can also be used in conjunction with the
 \code{pass_if_equal} option when the grading requirements are more involved.}
 
-\item{pass_if_equal}{\verb{[logical(1)]}\cr When \code{TRUE} (default), the \code{.result}
-is compared to the \code{.solution} with \code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} after the
+\item{pass_if_equal}{\verb{[logical(1)]}\cr When \code{TRUE} (default for
+\code{grade_this_vector()} but not \code{grade_this_table()}), the \code{.result} is
+compared to the \code{.solution} with \code{\link[gradethis:pass_if_equal]{gradethis::pass_if_equal()}} after the
 \emph{pre check} and before calling the \pkg{tblcheck} grading function.}
 
 \item{...}{Additional arguments passed to \code{graded()} or additional data to be

--- a/tests/testthat/test-grade_this.R
+++ b/tests/testthat/test-grade_this.R
@@ -257,6 +257,7 @@ test_that("post_check test", {
 	grade_pass <-
 		tblcheck_test_grade({
 			grade_this_table(
+				pass_if_equal = TRUE,
 				post_check = {gradethis::fail_if(is.integer(.result$b), "Incorrect")},
 				correct = "Correct"
 			)(


### PR DESCRIPTION
To avoid costly comparisons through `waldo::compare()`. We've found in practice that this behavior should be opt-in (for tables, at least).
